### PR TITLE
Google認証の調整

### DIFF
--- a/src/app/api/auth/callback/route.ts
+++ b/src/app/api/auth/callback/route.ts
@@ -1,29 +1,20 @@
-import { NextResponse } from "next/server";
-import { supabaseServerClient } from "@/lib/supabaseServerClient";
+import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs'
+import { cookies } from 'next/headers'
+import { NextResponse } from 'next/server'
 
-export async function GET(request: Request) {
-  const { searchParams, origin } = new URL(request.url);
-  const code = searchParams.get("code");
-  // if "next" is in param, use it as the redirect URL
-  const next = searchParams.get("next") ?? "https://www.emompath.com/emoms";
+import type { NextRequest } from 'next/server'
+// import type { Database } from '@/lib/database.types'
+
+export async function GET(request: NextRequest) {
+  const requestUrl = new URL(request.url)
+  const code = requestUrl.searchParams.get('code')
 
   if (code) {
-    const supabase = supabaseServerClient;
-    const { error } = await supabase.auth.exchangeCodeForSession(code);
-    if (!error) {
-      const forwardedHost = request.headers.get("x-forwarded-host"); // original origin before load balancer
-      const isLocalEnv = process.env.NODE_ENV === "development";
-      if (isLocalEnv) {
-        // we can be sure that there is no load balancer in between, so no need to watch for X-Forwarded-Host
-        return NextResponse.redirect(`${origin}${next}`);
-      } else if (forwardedHost) {
-        return NextResponse.redirect(`https://${forwardedHost}${next}`);
-      } else {
-        return NextResponse.redirect(`${origin}${next}`);
-      }
-    }
+    const cookieStore = cookies()
+    const supabase = createRouteHandlerClient({ cookies: () => cookieStore })
+    await supabase.auth.exchangeCodeForSession(code)
   }
 
-  // return the user to an error page with instructions
-  return NextResponse.redirect(`${origin}/auth/auth-code-error`);
+  // URL to redirect to after sign in process completes
+  return NextResponse.redirect(requestUrl.origin)
 }

--- a/src/app/api/auth/signin-google/route.ts
+++ b/src/app/api/auth/signin-google/route.ts
@@ -13,7 +13,7 @@ export async function GET() {
     options: {
       // TODO: 公式リファレンスでは独自実装したRoute Handlerのエンドポイントを指定している
       // https://supabase.com/docs/guides/auth/social-login/auth-google
-      redirectTo: process.env.NEXT_PUBLIC_REDIRECT_URL,
+      redirectTo: `http://localhost:3000/api/auth/callback`,
     },
   });
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -18,15 +18,19 @@ const HomePage = () => {
   useEffect(() => {
     const fetchSession = async () => {
       const { data, error } = await supabase.auth.getSession();
+      console.log("data", data);
       // エラーがある場合のみログを出力
       if (error) {
         console.error("Error fetching session:", error.message);
       }
 
       if (error || !data.session) {
+        console.log("session", data.session);
+        console.log("error", error);
         // セッションが取得できなかった場合
         router.push("/auth/signin");
       } else {
+        console.log("/emomsへ遷移")
         // セッションが取得できた場合
         setSession(data.session);
         router.push("/emoms");


### PR DESCRIPTION
## 変更内容

Google認証のこれまでの動きは以下の通りです。
1. 「SIGN IN WITH GOOGLE」ボタンを押下する
2. 任意のGoogleアカウントを押下する
3. トップページ（/）に遷移する
4. クライアントサイドで認証情報が取得され、/emomsに遷移する
5. middlewareで認証情報が取得できないため、/auth/signinに遷移する

これを以下の流れで処理を行うように変更しました。
1. 「SIGN IN WITH GOOGLE」ボタンを押下する
2. 任意のGoogleアカウントを押下する
3. /api/auth/callbackにリクエストする
4. トップページ（/）に遷移する
5. クライアントサイドで認証情報が取得され、/emomsに遷移する
6. middlewareで認証情報が取得される
7. /emomsが表示される

## 原因

middlewareで認証情報を取得できておらず、/emomsに遷移した後に/auth/signinに遷移していました。
その要因は、認証に必要な`pqlyyzlckpswftwdngob-auth-token`の内容を取得できていなかったからだと思います。
/api/auth/callbackの処理では、URLに付与されたcodeを元にサインインするようになっており、cookieを設定する処理も含まれているため`pqlyyzlckpswftwdngob-auth-token`が取得可能になるのだと思います。
https://supabase.com/docs/guides/auth/auth-helpers/nextjs?queryGroups=language&language=ts#managing-sign-in-with-code-exchange
```ts
  if (code) {
    const cookieStore = cookies()
    const supabase = createRouteHandlerClient({ cookies: () => cookieStore })
    await supabase.auth.exchangeCodeForSession(code)
  }
```

## その他

あえてコンソールログの出力処理を残しているので、色々と動作確認してみてください。